### PR TITLE
Fix path matching logic

### DIFF
--- a/Matcha.xcodeproj/project.pbxproj
+++ b/Matcha.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Matcha/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -403,6 +404,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Matcha/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Matcha.xcodeproj/project.pbxproj
+++ b/Matcha.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = MatchaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -441,6 +442,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = MatchaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MatchaTests/MatchaTests.swift
+++ b/MatchaTests/MatchaTests.swift
@@ -32,13 +32,17 @@ class MatchaTests: XCTestCase {
         XCTAssertNil(matcha.matched(""))
         XCTAssertNil(Matcha(url: URL(string: "https://example.com/")!).matched("/path"))
         XCTAssertNil(Matcha(url: URL(string: "https://example.com/")!).matched(""))
-
         XCTAssertNotNil(matcha.matched("https://example.com/path/to/glory/"))
         XCTAssertNotNil(matcha.matched("https://example.com/path/to/glory"))
         XCTAssertNotNil(matcha.matched("/path/to/glory/"))
         XCTAssertNotNil(matcha.matched("/path/to/glory"))
         XCTAssertNotNil(Matcha(url: URL(string: "https://example.com/")!).matched("/"))
         XCTAssertNotNil(Matcha(url: URL(string: "https://example.com")!).matched("/"))
+        XCTAssertNotNil(matcha.matched("/path/{A}"))
+        XCTAssertEqual(matcha.matched("/path/{A}")?.value(of: "A"), "to/glory")
+        XCTAssertEqual(matcha.matched("/{A}")?.value(of: "A"), "path/to/glory")
+        XCTAssertEqual(matcha.matched("/{A}/{B}")?.value(of: "A"), "path/to")
+        XCTAssertEqual(matcha.matched("/{A}/{B}")?.value(of: "B"), "glory")
 
         let urlPattern = "https://example.com/{A}/{B}/{C}/"
         let urlPatternMatched = matcha.matched(urlPattern)


### PR DESCRIPTION
既存のMatchaのマッチングロジックは、patternとして渡したもののPathのコンポーネント数が一致していないとマッチできないので、マッチできるように修正。
テストも通っていることを確認

e.g.)
urlのpathが`/my/something/path` だったときに、 `/my/{parameter}` のpatternで `something/path` を取得できるように。